### PR TITLE
Bump jawn dependency to 0.8.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ scalacOptions ++= Seq(
   "-feature"
 )
 
-val JawnVersion = "0.8.0"
+val JawnVersion = "0.8.3"
 
 libraryDependencies ++= Seq(
   "org.spire-math" %% "jawn-parser" % JawnVersion,


### PR DESCRIPTION
Prior to 0.8.3, jawn had an unintentional runtime dependency on jmh, which is under an incompatible license. See https://github.com/non/jawn/issues/33#issuecomment-125674108.