### PR TITLE
Update project

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add to your build.sbt:
 ```
 resolvers += "bintray/rossabaker" at "http://dl.bintray.com/rossabaker/maven"
 
-libraryDependencies += "com.rossabaker" %% "jawn-streamz" % "0.1.0"
+libraryDependencies += "org.http4s" %% "jawn-streamz" % "0.1.0"
 
 // Pick your AST: https://github.com/non/jawn#supporting-external-asts-with-jawn
 libraryDependencies += "org.jsawn" %% "jawn-ast" % "0.5.4"

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import java.net.URL
+
 import SonatypeKeys._
 
 sonatypeSettings
@@ -10,7 +12,7 @@ version := "0.5.2"
 
 scalaVersion := "2.10.5"
 
-crossScalaVersions := Seq("2.10.5", "2.11.6")
+crossScalaVersions := Seq("2.10.5", "2.11.7")
 
 pomExtra := {
   <url>http://github.com/rossabaker/jawn-streamz</url>
@@ -19,14 +21,10 @@ pomExtra := {
     <developerConnection>scm:git:github.com/rossabaker/jawn-streamz</developerConnection>
     <url>github.com/rossabaker/jawn-streamz</url>
   </scm>
-  <developers>
-    <developer>
-      <id>rossabaker</id>
-      <name>Ross A. Baker</name>
-      <email>ross@rossabaker.com</email>
-    </developer>
-  </developers>
 }
+
+developers += Developer(id = "rossabaker", name = "Ross A. Baker", email = "ross@rossabaker.com",
+                        url = new URL("https://github.com/rossabaker"))
 
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
@@ -45,6 +43,6 @@ val JawnVersion = "0.8.3"
 libraryDependencies ++= Seq(
   "org.spire-math" %% "jawn-parser" % JawnVersion,
   "org.spire-math" %% "jawn-ast" % JawnVersion % "test",
-  "org.scalaz.stream" %% "scalaz-stream" % "0.7.1a",
-  "org.specs2" %% "specs2" % "2.4" % "test"
+  "org.scalaz.stream" %% "scalaz-stream" % "0.7.3a",
+  "org.specs2" %% "specs2-core" % "3.6.4" % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7-RC5
+sbt.version=0.13.9

--- a/src/test/scala/jawnstreamz/JawnStreamzSpec.scala
+++ b/src/test/scala/jawnstreamz/JawnStreamzSpec.scala
@@ -12,7 +12,7 @@ import scalaz.concurrent.Task
 import scalaz.stream.Process.Step
 import scalaz.stream.{Process, async, io}
 
-class JawnStreamzSpec extends Specification with NoTimeConversions {
+class JawnStreamzSpec extends Specification {
   def loadJson(name: String, chunkSize: Int = 1024): Process[Task, ByteVector]  = {
     val is = getClass.getResourceAsStream(s"${name}.json")
     Process.constant(chunkSize).toSource.through(io.chunkR(is))


### PR DESCRIPTION
The main motivation for this change is the fact that the latest version of http4s causes an sbt eviction warning because of the fact that this library still depended on scalaz-stream 7.1a.

While I was at it, I upgraded all the things.